### PR TITLE
Update svix sdk

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.18.0
-	github.com/svix/svix-webhooks v1.69.1-0.20250709134218-efa8ef1d179a
+	github.com/svix/svix-webhooks v1.76.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
 github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
-github.com/svix/svix-webhooks v1.69.1-0.20250709134218-efa8ef1d179a h1:UQYmw1hx3q4n5014qC5Nw7WOfvQYDrVXXNh12WbIEqY=
-github.com/svix/svix-webhooks v1.69.1-0.20250709134218-efa8ef1d179a/go.mod h1:BRbQWn/xdv6zSGULojHza0Yx+hDf+xUJ4s09t3HqJpI=
+github.com/svix/svix-webhooks v1.76.1 h1:bavDpSPErIXTcoksO7LJucdND3d4G3SnuQwJgyBC4Jw=
+github.com/svix/svix-webhooks v1.76.1/go.mod h1:BRbQWn/xdv6zSGULojHza0Yx+hDf+xUJ4s09t3HqJpI=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/internal/api_token_resource.go
+++ b/internal/api_token_resource.go
@@ -117,7 +117,7 @@ func (r *ApiTokenResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 	res, err := svx.Management.Authentication.CreateApiToken(
-		ctx,
+		ctx, env_id,
 		models.ApiTokenIn{
 			Name:   data.Name.ValueString(),
 			Scopes: scopes,
@@ -178,7 +178,7 @@ func (r *ApiTokenResource) Delete(ctx context.Context, req resource.DeleteReques
 
 	// call api
 	err = svx.Management.Authentication.ExpireApiToken(
-		ctx, key_id, models.ApiTokenExpireIn{
+		ctx, env_id, key_id, models.ApiTokenExpireIn{
 			Expiry: ptr(int32(0)),
 		},
 		&internalsvix.ManagementAuthenticationExpireApiTokenOptions{


### PR DESCRIPTION
Using the new (unreleased) `env_id` in path endpoints for api token CRUD