### PR TITLE
Add support for modifying otel configuration

### DIFF
--- a/docs/resources/environment_settings.md
+++ b/docs/resources/environment_settings.md
@@ -102,10 +102,23 @@ endpoints. Transformations are code that can change a message's HTTP
 method, destination URL, and payload body in-flight.
 - `enforce_https` (Boolean) Enforces HTTPS on all endpoints of this environment
 - `event_catalog_published` (Boolean) Enable this to make your Event Catalog public. You can find the link to the published Event Catalog at https://dashboard.svix.com/settings/organization/catalog
+- `otel_config` (Attributes) <strong>Requires Enterprise plan</strong>, Configure OpenTelemetry (OTEL) tracing for this environment. Setting this block enables OpenTelemetry exports; removing it disables exports and deletes the stored config. (see [below for nested schema](#nestedatt--otel_config))
 - `require_endpoint_channels` (Boolean) If enabled, all new Endpoints must filter on at least one channel.
 - `require_endpoint_event_types` (Boolean) If enabled, all new Endpoints must filter on at least one event type.
 - `whitelabel_headers` (Boolean) <strong>Requires Pro or Enterprise plan</strong>, Changes the prefix of the webhook HTTP headers to use the`webhook-` prefix. <strong>Changing this setting can break existing integrations</strong>
 - `whitelabel_settings` (Attributes) Customize how the [Consumer App Portal](https://docs.svix.com/management-ui) will look for your users in this environment. (see [below for nested schema](#nestedatt--whitelabel_settings))
+
+<a id="nestedatt--otel_config"></a>
+### Nested Schema for `otel_config`
+
+Required:
+
+- `url` (String) OTEL collector endpoint URL
+
+Optional:
+
+- `additional_headers` (Map of String, Sensitive) Additional HTTP headers to include with exports
+
 
 <a id="nestedatt--whitelabel_settings"></a>
 ### Nested Schema for `whitelabel_settings`

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-framework-jsontypes v0.2.0
 	github.com/hashicorp/terraform-plugin-framework-timetypes v0.5.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.19.0
-	github.com/svix/svix-webhooks v1.88.0
+	github.com/svix/svix-webhooks v1.95.2
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/svix/svix-webhooks v1.88.0 h1:dpqnfkXKlEIyIZ5txCsAJyWiLGkVUNIoLhG49tg2I28=
-github.com/svix/svix-webhooks v1.88.0/go.mod h1:BRbQWn/xdv6zSGULojHza0Yx+hDf+xUJ4s09t3HqJpI=
+github.com/svix/svix-webhooks v1.95.2 h1:k+jlmo8W9EFXiORADXERqne6Bk7zjEm5lCjatc7aXqw=
+github.com/svix/svix-webhooks v1.95.2/go.mod h1:ngWxEvc1ll097e5kjOQfLz6PqjZTep6ORvGsV4s6mYg=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/internal/environment_settings.go
+++ b/internal/environment_settings.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	svix_internal "github.com/svix/svix-webhooks/go/internalapi"
 	"github.com/svix/svix-webhooks/go/models"
 	"github.com/svix/terraform-provider-svix/internal/generated"
 )
@@ -335,6 +336,22 @@ method, destination URL, and payload body in-flight.`,
 delivered to the endpoint. Only affects messages sent after this
 setting is enabled.`,
 			},
+			"otel_config": schema.SingleNestedAttribute{
+				Optional:            true,
+				MarkdownDescription: REQUIRES_ENTERPRISE_PLAN + "Configure OpenTelemetry (OTEL) tracing for this environment. Setting this block enables OpenTelemetry exports; removing it disables exports and deletes the stored config.",
+				Attributes: map[string]schema.Attribute{
+					"url": schema.StringAttribute{
+						Required:    true,
+						Description: "OTEL collector endpoint URL",
+					},
+					"additional_headers": schema.MapAttribute{
+						Optional:    true,
+						Sensitive:   true,
+						ElementType: types.StringType,
+						Description: "Additional HTTP headers to include with exports",
+					},
+				},
+			},
 		},
 	}
 
@@ -359,12 +376,12 @@ func (r *EnvironmentSettingsResource) Configure(ctx context.Context, req resourc
 func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
 	// load state/plan
 	var data generated.EnvironmentSettingsResourceModel
-	var envId string
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	resp.Diagnostics.Append(req.Plan.GetAttribute(ctx, path.Root("environment_id"), &envId)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	envId := data.EnvironmentId.ValueString()
 
 	// create svix client
 	svx, err := r.state.InternalClientWithEnvId(envId)
@@ -378,6 +395,23 @@ func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
+	currentOtel, _ := svx.Management.EnvironmentSettings.GetOtelConfig(ctx)
+
+	otelConfigOut, diags := applyOtelConfig(ctx, svx, data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if currentOtel == nil || !currentOtel.SvixManaged {
+		if !data.OtelConfig.IsNull() && !data.OtelConfig.IsUnknown() {
+			enabled := true
+			settingsPatch.EnableOtlp = &enabled
+		} else {
+			disabled := false
+			settingsPatch.EnableOtlp = &disabled
+		}
+	}
+
 	// call api
 	res, err := svx.Management.EnvironmentSettings.Patch(ctx, settingsPatch)
 	if err != nil {
@@ -385,7 +419,7 @@ func (r *EnvironmentSettingsResource) Create(ctx context.Context, req resource.C
 		return
 	}
 
-	outModel := internalSettingsOutToTF(ctx, &resp.Diagnostics, *res, envId)
+	outModel := internalSettingsOutToTF(ctx, &resp.Diagnostics, *res, envId, otelConfigOut)
 	resp.Diagnostics.Append(resp.State.Set(ctx, outModel)...)
 }
 
@@ -410,7 +444,12 @@ func (r *EnvironmentSettingsResource) Read(ctx context.Context, req resource.Rea
 		return
 	}
 
-	outModel := internalSettingsOutToTF(ctx, &resp.Diagnostics, *res, envId)
+	var otelConfigOut *models.OtelConfigOut
+	if res.EnableOtlp != nil && *res.EnableOtlp {
+		otelConfigOut, _ = svx.Management.EnvironmentSettings.GetOtelConfig(ctx)
+	}
+
+	outModel := internalSettingsOutToTF(ctx, &resp.Diagnostics, *res, envId, otelConfigOut)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, outModel)...)
 }
@@ -418,12 +457,12 @@ func (r *EnvironmentSettingsResource) Read(ctx context.Context, req resource.Rea
 func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// load state/plan
 	var data generated.EnvironmentSettingsResourceModel
-	var envId string
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
-	resp.Diagnostics.Append(req.State.GetAttribute(ctx, path.Root("environment_id"), &envId)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	envId := data.EnvironmentId.ValueString()
 
 	// create svix client
 	svx, err := r.state.InternalClientWithEnvId(envId)
@@ -437,6 +476,23 @@ func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
+	currentOtel, _ := svx.Management.EnvironmentSettings.GetOtelConfig(ctx)
+
+	otelConfigOut, diags := applyOtelConfig(ctx, svx, data)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if currentOtel == nil || !currentOtel.SvixManaged {
+		if !data.OtelConfig.IsNull() && !data.OtelConfig.IsUnknown() {
+			enabled := true
+			settingsPatch.EnableOtlp = &enabled
+		} else {
+			disabled := false
+			settingsPatch.EnableOtlp = &disabled
+		}
+	}
+
 	// call api
 	res, err := svx.Management.EnvironmentSettings.Patch(ctx, settingsPatch)
 	if err != nil {
@@ -444,7 +500,11 @@ func (r *EnvironmentSettingsResource) Update(ctx context.Context, req resource.U
 		return
 	}
 
-	outModel := internalSettingsOutToTF(ctx, &resp.Diagnostics, *res, envId)
+	if data.OtelConfig.IsNull() || data.OtelConfig.IsUnknown() {
+		deleteOtelConfig(ctx, svx, currentOtel)
+	}
+
+	outModel := internalSettingsOutToTF(ctx, &resp.Diagnostics, *res, envId, otelConfigOut)
 	resp.Diagnostics.Append(resp.State.Set(ctx, outModel)...)
 }
 
@@ -481,9 +541,56 @@ func isWhitelabelSettingsEmpty(w generated.WhitelabelSettings) bool {
 		w.CustomStringsOverride.IsNull()
 }
 
-func internalSettingsOutToTF(ctx context.Context, d *diag.Diagnostics, v models.SettingsInternalOut, envId string) generated.EnvironmentSettingsResourceModel {
+func deleteOtelConfig(ctx context.Context, svx *svix_internal.InternalSvix, current *models.OtelConfigOut) {
+	if current == nil || current.SvixManaged {
+		return
+	}
+	_ = svx.Management.EnvironmentSettings.DeleteOtelConfig(ctx)
+}
+
+func applyOtelConfig(ctx context.Context, svx *svix_internal.InternalSvix, data generated.EnvironmentSettingsResourceModel) (*models.OtelConfigOut, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	if data.OtelConfig.IsNull() || data.OtelConfig.IsUnknown() {
+		return nil, diags
+	}
+
+	var otelCfgTF OtelConfig_TF
+	diags.Append(data.OtelConfig.As(ctx, &otelCfgTF, basetypes.ObjectAsOptions{})...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	otelConfig := models.OtelConfig{
+		Url: otelCfgTF.Url.ValueString(),
+	}
+	if !otelCfgTF.AdditionalHeaders.IsNull() && !otelCfgTF.AdditionalHeaders.IsUnknown() {
+		headers := map[string]string{}
+		diags.Append(otelCfgTF.AdditionalHeaders.ElementsAs(ctx, &headers, false)...)
+		if diags.HasError() {
+			return nil, diags
+		}
+		if len(headers) > 0 {
+			otelConfig.AdditionalHeaders = &headers
+		}
+	}
+
+	if err := svx.Management.EnvironmentSettings.UpdateOtelConfig(ctx, otelConfig); err != nil {
+		diags.AddError("Failed to update OTEL config", err.Error())
+		return nil, diags
+	}
+
+	out := &models.OtelConfigOut{
+		Url:               &otelConfig.Url,
+		AdditionalHeaders: otelConfig.AdditionalHeaders,
+	}
+	return out, diags
+}
+
+func internalSettingsOutToTF(ctx context.Context, d *diag.Diagnostics, v models.SettingsInternalOut, envId string, otelConfig *models.OtelConfigOut) generated.EnvironmentSettingsResourceModel {
 	out := generated.EnvironmentSettingsResourceModel{
 		WhitelabelSettings:         basetypes.NewObjectNull(generated.WhitelabelSettings_TF_AttributeTypes()),
+		OtelConfig:                 basetypes.NewObjectNull(OtelConfig_TF_AttributeTypes()),
 		EnvironmentId:              types.StringValue(envId),
 		DisableEndpointOnFailure:   types.BoolPointerValue(v.DisableEndpointOnFailure),
 		EnableChannels:             types.BoolPointerValue(v.EnableChannels),
@@ -497,6 +604,22 @@ func internalSettingsOutToTF(ctx context.Context, d *diag.Diagnostics, v models.
 		RequireEndpointFilterTypes: types.BoolPointerValue(v.RequireEndpointFilterTypes),
 		WhitelabelHeaders:          types.BoolPointerValue(v.WhitelabelHeaders),
 		WipeSuccessfulPayload:      types.BoolPointerValue(v.WipeSuccessfulPayload),
+	}
+
+	if otelConfig != nil && otelConfig.Url != nil {
+		headers := types.MapNull(types.StringType)
+		if otelConfig.AdditionalHeaders != nil && len(*otelConfig.AdditionalHeaders) > 0 {
+			h, diags := types.MapValueFrom(ctx, types.StringType, *otelConfig.AdditionalHeaders)
+			d.Append(diags...)
+			headers = h
+		}
+		otelCfgTF := OtelConfig_TF{
+			Url:               types.StringPointerValue(otelConfig.Url),
+			AdditionalHeaders: headers,
+		}
+		otelObj, diags := types.ObjectValueFrom(ctx, otelCfgTF.AttributeTypes(), otelCfgTF)
+		d.Append(diags...)
+		out.OtelConfig = otelObj
 	}
 
 	{

--- a/internal/generated/environment_settings.go
+++ b/internal/generated/environment_settings.go
@@ -51,6 +51,7 @@ type EnvironmentSettingsResourceModel struct {
 	WipeSuccessfulPayload      types.Bool   `tfsdk:"delete_payload_on_successful_delivery"`
 
 	WhitelabelSettings basetypes.ObjectValue `tfsdk:"whitelabel_settings"`
+	OtelConfig         basetypes.ObjectValue `tfsdk:"otel_config"`
 }
 
 type WhitelabelSettings struct {

--- a/internal/otel_config.go
+++ b/internal/otel_config.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type OtelConfig_TF struct {
+	Url               types.String `tfsdk:"url"`
+	AdditionalHeaders types.Map    `tfsdk:"additional_headers"`
+}
+
+func OtelConfig_TF_AttributeTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"url":                types.StringType,
+		"additional_headers": types.MapType{ElemType: types.StringType},
+	}
+}
+
+func (v *OtelConfig_TF) AttributeTypes() map[string]attr.Type {
+	return OtelConfig_TF_AttributeTypes()
+}

--- a/internal/provider.go
+++ b/internal/provider.go
@@ -148,7 +148,7 @@ func (s *appState) DefaultSvixClient() (*svix.Svix, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = svix.SetUserAgentSuffix(svx, userAgentSuffix)
+	err = svx.SetUserAgentSuffix(userAgentSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +162,7 @@ func (s *appState) ClientWithEnvId(envId string) (*svix.Svix, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = svix.SetUserAgentSuffix(svx, userAgentSuffix)
+	err = svx.SetUserAgentSuffix(userAgentSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func (s *appState) ClientWithEnvId(envId string) (*svix.Svix, error) {
 // create a new internal svix client with the envId suffixed on the token
 func (s *appState) InternalClientWithEnvId(envId string) (*svix_internal.InternalSvix, error) {
 	bearerToken := fmt.Sprintf("%s|%s", s.token, envId)
-	svx, err := svix_internal.New(bearerToken, &s.serverUrl, s.debug, userAgentSuffix)
+	svx, err := svix_internal.New(bearerToken, &s.serverUrl, s.debug, &userAgentSuffix)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (s *appState) InternalClientWithEnvId(envId string) (*svix_internal.Interna
 
 // get the default internal svix client without an envId suffixed
 func (s *appState) InternalDefaultSvixClient() (*svix_internal.InternalSvix, error) {
-	svx, err := svix_internal.New(s.token, &s.serverUrl, s.debug, userAgentSuffix)
+	svx, err := svix_internal.New(s.token, &s.serverUrl, s.debug, &userAgentSuffix)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Support updating OTEL configuration (only supported for Enterprise customers). Pretty straightforward. The biggest thing to note is that Svix manages
this configuration for some customers. In those
cases, the existing OTEL configuration will not be modified.